### PR TITLE
Tabs are forbidden in YAML as per the spec.

### DIFF
--- a/config.yaml.sample
+++ b/config.yaml.sample
@@ -6,16 +6,16 @@ saved_configs_dir: "./configs/"
 
 # The dpid of a switch in hex
 0x1a5:
-	"name": "The friendly name for this switch"
-	"blocked": [1,3] # These are inaccessible
-	"mininet": [5-9] # [5,6,7,8,9,10]
-	# Almost anything will work here as long as it is non-numeric
-	"switch1": [20,10to14] # [10,11,12,13,14,20]
-	# but you probably should not
-	"switch2": [15+19] # [15,16,17,18,19]
-	"controller": 6 # [6]
+    "name": "The friendly name for this switch"
+    "blocked": [1,3] # These are inaccessible
+    "mininet": [5-9] # [5,6,7,8,9,10]
+    # Almost anything will work here as long as it is non-numeric
+    "switch1": [20,10to14] # [10,11,12,13,14,20]
+    # but you probably should not
+    "switch2": [15+19] # [15,16,17,18,19]
+    "controller": 6 # [6]
 
 # Another switch the dpid of a switch in decimal
 10:
-	#empty
+    #empty
 # This is valid, the names for ports are taken from the switch


### PR DESCRIPTION
"Tabs have been outlawed since they are treated differently by
different editors and tools. And since indentation is so critical to
proper interpretation of YAML, this issue is just too tricky to even
attempt. Indeed Guido van Rossum of Python has acknowledged that
allowing TABs in Python source is a headache for many people and that
were he to design Python again, he would forbid them."